### PR TITLE
Add LF as a valid line terminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added Linefeed as a valid line terminator
+
 ## [0.2.0] - 2022-03-22
 
 - Added basic line history

--- a/noline/Cargo.toml
+++ b/noline/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num_enum = {version = "0.5.6", default-features = false}
+num_enum = {version = "0.7.0", default-features = false}
 embedded-hal = {version = "0.2.6", optional = true}
 nb = {version = "1.0.0", optional = true}
 tokio = {version = "1.16.1", optional = true, features = ["io-util", "sync"]}
@@ -31,7 +31,7 @@ alloc = []
 [dev-dependencies]
 crossbeam = "0.8.1"
 nb = {version = "1.0.0"}
-termion = "1.5.6"
+termion = "2.0.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/noline/src/core.rs
+++ b/noline/src/core.rs
@@ -248,7 +248,7 @@ impl<'a, B: Buffer, H: History> Line<'a, B, H> {
                     let move_cursor = -(self.buffer.delete_previous_word(pos) as isize);
                     self.generate_output(MoveCursorAndEraseAndPrintBuffer(move_cursor))
                 }
-                CarriageReturn => {
+                CarriageReturn | LineFeed => {
                     if self.buffer.len() > 0 {
                         let _ = self.nav.history.add_entry(self.buffer.as_str());
                     }


### PR DESCRIPTION
Useful for when piping from unix which generates LF, not CRLF

For example:

```bash
> echo "Hello world" | base64 -b 8 -i - | cat -e 
SGVsbG8g$
d29ybGQK$
$
$
```

The $ indicates a LF.  If it was to have CRLF, it would show ast ^M$