### PR TITLE
Allow prompt to be created from iterator over `&str`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Bugfix: Char boundary string splitting error
+- Allow dynamic prompt made from iterator over `&str`
 
 ## [0.4.0 - 2024-08-27]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bugfix: Char boundary string splitting error
 - Allow dynamic prompt made from iterator over `&str`
+- Take slice instead of owning buffer for line and history
 
 ## [0.4.0 - 2024-08-27]
 

--- a/examples/no_std/rp2040-embassy/src/noline_async.rs
+++ b/examples/no_std/rp2040-embassy/src/noline_async.rs
@@ -108,6 +108,7 @@ pub async fn cli<'d, T: Instance + 'd>(
     let prompt = "> ";
 
     let mut io = IO::new(recv, send);
+    let buffer = [0; MAX_LINE_SIZE];
 
     loop {
         io.stdout.wait_connection().await;
@@ -116,7 +117,7 @@ pub async fn cli<'d, T: Instance + 'd>(
             control.control_changed().await;
         }
 
-        let mut editor = EditorBuilder::new_static::<MAX_LINE_SIZE>()
+        let mut editor = EditorBuilder::from_slice(&mut buffer)
             .with_static_history::<MAX_LINE_SIZE>()
             .build_async(&mut io)
             .await

--- a/examples/no_std/rp2040-embassy/src/noline_async.rs
+++ b/examples/no_std/rp2040-embassy/src/noline_async.rs
@@ -108,7 +108,8 @@ pub async fn cli<'d, T: Instance + 'd>(
     let prompt = "> ";
 
     let mut io = IO::new(recv, send);
-    let buffer = [0; MAX_LINE_SIZE];
+    let mut buffer = [0; MAX_LINE_SIZE];
+    let mut history = [0; MAX_LINE_SIZE];
 
     loop {
         io.stdout.wait_connection().await;
@@ -118,7 +119,7 @@ pub async fn cli<'d, T: Instance + 'd>(
         }
 
         let mut editor = EditorBuilder::from_slice(&mut buffer)
-            .with_static_history::<MAX_LINE_SIZE>()
+            .with_slice_history(&mut history)
             .build_async(&mut io)
             .await
             .unwrap();

--- a/examples/no_std/rp2040/src/main.rs
+++ b/examples/no_std/rp2040/src/main.rs
@@ -169,7 +169,8 @@ fn main() -> ! {
 
     info!("Waiting for connection");
 
-    let mut editor = EditorBuilder::new_static::<128>()
+    let mut buffer = [0; 128];
+    let mut editor = EditorBuilder::from_slice(&mut buffer)
         .with_static_history::<128>()
         .build_sync(&mut io)
         .unwrap();

--- a/examples/no_std/rp2040/src/main.rs
+++ b/examples/no_std/rp2040/src/main.rs
@@ -170,8 +170,9 @@ fn main() -> ! {
     info!("Waiting for connection");
 
     let mut buffer = [0; 128];
+    let mut history = [0; 128];
     let mut editor = EditorBuilder::from_slice(&mut buffer)
-        .with_static_history::<128>()
+        .with_slice_history(&mut history)
         .build_sync(&mut io)
         .unwrap();
 

--- a/examples/std/src/bin/std-async-tokio.rs
+++ b/examples/std/src/bin/std-async-tokio.rs
@@ -24,14 +24,10 @@ impl embedded_io_async::ErrorType for IOWrapper {
 
 impl embedded_io_async::Read for IOWrapper {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        let mut b = [0];
-        let _ = self
-            .stdin
-            .read_exact(&mut b)
+        self.stdin
+            .read(buf)
             .await
-            .map_err(|e| Self::Error::from(e.kind()))?;
-        buf[0] = b[0];
-        Ok(1)
+            .map_err(|e| Self::Error::from(e.kind()))
     }
 }
 

--- a/examples/std/src/bin/std-async-tokio.rs
+++ b/examples/std/src/bin/std-async-tokio.rs
@@ -40,7 +40,7 @@ impl embedded_io_async::Write for IOWrapper {
     }
 }
 
-#[tokio::main(flavor = "multi_thread")]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let term_task = tokio::spawn(async {
         let _raw_term = std::io::stdout().into_raw_mode().unwrap();

--- a/examples/std/src/bin/std-sync.rs
+++ b/examples/std/src/bin/std-sync.rs
@@ -31,11 +31,7 @@ impl ErrorType for IOWrapper {
 
 impl EmbRead for IOWrapper {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        let _ = self
-            .stdin
-            .read_exact(&mut buf[0..1])
-            .map_err(|e| e.kind())?;
-        Ok(1)
+        Ok(self.stdin.read(buf).map_err(|e| e.kind())?)
     }
 }
 

--- a/noline/src/async_editor.rs
+++ b/noline/src/async_editor.rs
@@ -30,6 +30,7 @@ where
     /// Create and initialize line editor
     pub async fn new<IO: embedded_io_async::Read + embedded_io_async::Write>(
         buffer: LineBuffer<B>,
+        history: H,
         io: &mut IO,
     ) -> Result<Self, NolineError> {
         let mut initializer = Initializer::new();
@@ -60,7 +61,7 @@ where
         Ok(Self {
             buffer,
             terminal,
-            history: H::default(),
+            history,
         })
     }
 

--- a/noline/src/async_editor.rs
+++ b/noline/src/async_editor.rs
@@ -29,6 +29,7 @@ where
 {
     /// Create and initialize line editor
     pub async fn new<IO: embedded_io_async::Read + embedded_io_async::Write>(
+        buffer: LineBuffer<B>,
         io: &mut IO,
     ) -> Result<Self, NolineError> {
         let mut initializer = Initializer::new();
@@ -57,7 +58,7 @@ where
         };
 
         Ok(Self {
-            buffer: LineBuffer::new(),
+            buffer,
             terminal,
             history: H::default(),
         })

--- a/noline/src/builder.rs
+++ b/noline/src/builder.rs
@@ -57,7 +57,7 @@ impl EditorBuilder<NoBuffer, NoHistory> {
         }
     }
 
-    #[cfg(any(test, feature = "alloc", feature = "std"))]
+    #[cfg(any(test, doc, feature = "alloc", feature = "std"))]
     /// Create builder for editor with unbounded buffer
     ///
     /// # Example

--- a/noline/src/history.rs
+++ b/noline/src/history.rs
@@ -376,7 +376,7 @@ impl<'a, H: History> HistoryNavigator<'a, H> {
     }
 }
 
-#[cfg(any(test, feature = "alloc", feature = "std"))]
+#[cfg(any(test, doc, feature = "alloc", feature = "std"))]
 mod alloc {
     use super::*;
     use alloc::{

--- a/noline/src/history.rs
+++ b/noline/src/history.rs
@@ -425,7 +425,7 @@ mod alloc {
     }
 }
 
-#[cfg(any(test, feature = "alloc", feature = "std"))]
+#[cfg(any(test, doc, feature = "alloc", feature = "std"))]
 pub use alloc::UnboundedHistory;
 
 #[cfg(test)]

--- a/noline/src/line_buffer.rs
+++ b/noline/src/line_buffer.rs
@@ -280,7 +280,7 @@ impl<const N: usize> Buffer for StaticBuffer<N> {
     }
 }
 
-#[cfg(any(test, feature = "alloc", feature = "std"))]
+#[cfg(any(test, doc, feature = "alloc", feature = "std"))]
 mod alloc {
     extern crate alloc;
 
@@ -316,7 +316,7 @@ mod alloc {
     }
 }
 
-#[cfg(any(test, feature = "alloc", feature = "std"))]
+#[cfg(any(test, doc, feature = "alloc", feature = "std"))]
 pub use self::alloc::*;
 
 #[cfg(test)]

--- a/noline/src/output.rs
+++ b/noline/src/output.rs
@@ -797,7 +797,7 @@ mod tests {
         }
 
         let prompt: Prompt<StrIter> = "> ".into();
-        let mut line_buffer = LineBuffer::<Vec<u8>>::new();
+        let mut line_buffer = LineBuffer::new_unbounded();
         let mut terminal = Terminal::new(4, 10, Cursor::new(0, 0));
 
         let result = to_string(Output::new(

--- a/noline/src/sync_editor.rs
+++ b/noline/src/sync_editor.rs
@@ -43,7 +43,11 @@ where
     H: History,
 {
     /// Create and initialize line editor
-    pub fn new<IO: Read + Write>(buffer: LineBuffer<B>, io: &mut IO) -> Result<Self, NolineError> {
+    pub fn new<IO: Read + Write>(
+        buffer: LineBuffer<B>,
+        history: H,
+        io: &mut IO,
+    ) -> Result<Self, NolineError> {
         let mut initializer = Initializer::new();
 
         io.write(Initializer::init())?;
@@ -73,7 +77,7 @@ where
         Ok(Self {
             buffer,
             terminal,
-            history: H::default(),
+            history,
         })
     }
 

--- a/noline/src/sync_editor.rs
+++ b/noline/src/sync_editor.rs
@@ -43,7 +43,7 @@ where
     H: History,
 {
     /// Create and initialize line editor
-    pub fn new<IO: Read + Write>(io: &mut IO) -> Result<Self, NolineError> {
+    pub fn new<IO: Read + Write>(buffer: LineBuffer<B>, io: &mut IO) -> Result<Self, NolineError> {
         let mut initializer = Initializer::new();
 
         io.write(Initializer::init())?;
@@ -71,7 +71,7 @@ where
         };
 
         Ok(Self {
-            buffer: LineBuffer::new(),
+            buffer,
             terminal,
             history: H::default(),
         })


### PR DESCRIPTION
To integrate `noline` with `menu`, we need to allow dynamic prompt created from iterator over `&str`.

rust-embedded-community/menu#24