### PR TITLE
Probe terminal size for every line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removed initializer. Probe terminal size before prompt for every line.
+
 ## [0.5.0 - 2024-08-30]
 
 - Bugfix: Char boundary string splitting error

--- a/noline/src/async_editor.rs
+++ b/noline/src/async_editor.rs
@@ -5,7 +5,7 @@
 use embedded_io_async::ReadExactError;
 
 use crate::{
-    core::{Initializer, InitializerResult, Line, Prompt},
+    core::{Line, Prompt},
     error::NolineError,
     history::{get_history_entries, CircularSlice, History},
     line_buffer::{Buffer, LineBuffer},
@@ -31,32 +31,9 @@ where
     pub async fn new<IO: embedded_io_async::Read + embedded_io_async::Write>(
         buffer: LineBuffer<B>,
         history: H,
-        io: &mut IO,
+        _io: &mut IO,
     ) -> Result<Self, NolineError> {
-        let mut initializer = Initializer::new();
-
-        io.write(Initializer::init()).await?;
-
-        io.flush().await?;
-
-        let terminal = loop {
-            let mut buf = [0u8; 1];
-            // let len = io.read_exact(&mut buf).await?;
-
-            match io.read_exact(&mut buf).await {
-                Ok(_) => (),
-                Err(err) => match err {
-                    ReadExactError::UnexpectedEof => return Err(NolineError::Aborted),
-                    ReadExactError::Other(err) => Err(err)?,
-                },
-            }
-
-            match initializer.advance(buf[0]) {
-                InitializerResult::Continue => (),
-                InitializerResult::Item(terminal) => break terminal,
-                InitializerResult::InvalidInput => return Err(NolineError::ParserError),
-            }
-        };
+        let terminal = Terminal::default();
 
         Ok(Self {
             buffer,
@@ -90,6 +67,21 @@ where
         Ok(None)
     }
 
+    async fn read_byte<IO>(io: &mut IO) -> Result<u8, NolineError>
+    where
+        IO: embedded_io_async::Read + embedded_io_async::Write,
+    {
+        let mut buf = [0x8; 1];
+
+        match io.read_exact(&mut buf).await {
+            Ok(_) => Ok(buf[0]),
+            Err(err) => match err {
+                ReadExactError::UnexpectedEof => Err(NolineError::Aborted),
+                ReadExactError::Other(err) => Err(err)?,
+            },
+        }
+    }
+
     /// Read line from `stdin`
     pub async fn readline<'b, 'item, IO, I>(
         &'b mut self,
@@ -106,24 +98,26 @@ where
             &mut self.terminal,
             &mut self.history,
         );
-        Self::handle_output(line.reset(), io).await?;
+
+        let mut reset = line.reset();
+
+        Self::handle_output(reset.start(), io).await?;
 
         loop {
-            let mut buf = [0x8; 1];
+            let byte = Self::read_byte(io).await?;
 
-            match io.read_exact(&mut buf).await {
-                Ok(_) => {
-                    if Self::handle_output(line.advance(buf[0]), io)
-                        .await?
-                        .is_some()
-                    {
-                        break;
-                    }
-                }
-                Err(err) => match err {
-                    ReadExactError::UnexpectedEof => return Err(NolineError::Aborted),
-                    ReadExactError::Other(err) => Err(err)?,
-                },
+            if let Some(output) = reset.advance(byte) {
+                Self::handle_output(output, io).await?;
+            } else {
+                break;
+            }
+        }
+
+        loop {
+            let byte = Self::read_byte(io).await?;
+
+            if Self::handle_output(line.advance(byte), io).await?.is_some() {
+                break;
             }
         }
 

--- a/noline/src/core.rs
+++ b/noline/src/core.rs
@@ -408,6 +408,7 @@ pub(crate) mod tests {
 
             let mut reset_start: Vec<u8> = reset
                 .start()
+                .into_iter()
                 .filter_map(|item| item.get_bytes().map(|bytes| bytes.to_vec()))
                 .flatten()
                 .collect();
@@ -425,6 +426,7 @@ pub(crate) mod tests {
                     .filter_map(|b| {
                         reset.advance(b).map(|output| {
                             output
+                                .into_iter()
                                 .map(|item| item.get_bytes().map(|bytes| bytes.to_vec()))
                                 .collect::<Vec<_>>()
                         })
@@ -501,6 +503,7 @@ pub(crate) mod tests {
 
         let probe = reset
             .start()
+            .into_iter()
             .flat_map(|item| item.get_bytes().unwrap().to_vec())
             .collect::<Vec<u8>>();
 

--- a/noline/src/terminal.rs
+++ b/noline/src/terminal.rs
@@ -42,6 +42,12 @@ pub struct Terminal {
     row_offset: isize,
 }
 
+impl Default for Terminal {
+    fn default() -> Self {
+        Self::new(24, 80, Cursor::new(0, 0))
+    }
+}
+
 impl Terminal {
     pub fn new(rows: usize, columns: usize, cursor: Cursor) -> Self {
         let row_offset = -(cursor.row as isize);
@@ -52,6 +58,11 @@ impl Terminal {
             cursor,
             row_offset,
         }
+    }
+
+    pub fn resize(&mut self, rows: usize, columns: usize) {
+        self.rows = rows;
+        self.columns = columns;
     }
 
     pub fn reset(&mut self, cursor: Cursor) {
@@ -147,6 +158,11 @@ impl Terminal {
 
     pub fn columns_remaining(&self) -> usize {
         self.columns - self.cursor.column
+    }
+
+    #[cfg(test)]
+    pub fn get_size(&self) -> (usize, usize) {
+        (self.rows, self.columns)
     }
 }
 

--- a/noline/src/testlib.rs
+++ b/noline/src/testlib.rs
@@ -1,3 +1,4 @@
+use core::time::Duration;
 use std::string::String;
 use std::thread;
 use std::thread::JoinHandle;
@@ -24,8 +25,8 @@ pub struct MockTerminal {
     parser: Parser,
     screen: Vec<Vec<char>>,
     pub cursor: Cursor,
-    rows: usize,
-    columns: usize,
+    pub rows: usize,
+    pub columns: usize,
     saved_cursor: Option<Cursor>,
     pub bell: bool,
     pub terminal_tx: Option<Sender<u8>>,
@@ -256,6 +257,7 @@ pub trait ToByteVec {
     fn to_byte_vec(self) -> Vec<u8>;
 }
 
+#[derive(Debug)]
 pub struct TestCase {
     pub input: Vec<Vec<u8>>,
     pub output: Vec<String>,
@@ -372,6 +374,9 @@ pub fn test_editor_with_case<IO: Send + 'static>(
             string_rx.recv().unwrap()
         })
         .collect();
+
+    // Added delay to prevent race with terminal reset
+    std::thread::sleep(Duration::from_millis(100));
 
     keyboard_tx.send(0x3).unwrap();
 


### PR DESCRIPTION
Noline initializes the terminal once, probing the size of the terminal. In #35 a new feature was proposed to be able to re-initialize the terminal. The initializer is a bit strict, and will cause an error if the input from the terminal is not exactly as expected, as seen in #12.

This PR solves both these problems by:
- Removing initializer, and probing terminal size for every line.
- In case of unexpected input during probing, set terminal size to 24x80, and continue normal operation.