### PR TITLE
Bugfix: Missing CPR arguments causes panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bugfix: Missing CPR arguments causes panic
+
 ## [0.5.0 - 2024-12-12]
 
 - Removed initializer. Probe terminal size before prompt for every line.

--- a/noline/src/core.rs
+++ b/noline/src/core.rs
@@ -353,6 +353,7 @@ where
                 CSI::DSR => self.generate_output(RingBell),
                 CSI::SU(_) => self.generate_output(RingBell),
                 CSI::SD(_) => self.generate_output(RingBell),
+                CSI::Invalid => self.generate_output(RingBell),
             },
             Action::EscapeSequence(_) => self.generate_output(RingBell),
             Action::Ignore => self.generate_output(Nothing),

--- a/noline/src/testlib.rs
+++ b/noline/src/testlib.rs
@@ -152,6 +152,7 @@ impl MockTerminal {
                 CSI::Home => unimplemented!(),
                 CSI::Delete => unimplemented!(),
                 CSI::End => unimplemented!(),
+                CSI::Invalid => unimplemented!(),
             },
             Action::InvalidUtf8 => unreachable!(),
             Action::ControlCharacter(ctrl) => {


### PR DESCRIPTION
- Added `CSI::Invalid` and return that if CPR is missing arguments No
- No need for `CSI::new()` to return `Option` as `None` value is never created.
- Added test